### PR TITLE
Fixes `has` false-positive for expired transients

### DIFF
--- a/src/CachePool.php
+++ b/src/CachePool.php
@@ -191,8 +191,7 @@ class CachePool implements CacheInterface
     public function has($key)
     {
         $default = $this->defaultValue;
-        $prefix = $this->getOptionNamePrefix();
-        $value = $this->getOption("{$prefix}{$key}", $default);
+        $value = $this->get($key, $default);
 
         return $value !== $default;
     }

--- a/tests/functional/CachePoolTest.php
+++ b/tests/functional/CachePoolTest.php
@@ -313,18 +313,16 @@ class CachePoolTest extends TestCase
             $defaultValue = uniqid('default');
             $wpdb = $this->createWpdb();
             $key = uniqid('key');
-            $separator = TestSubject::NAMESPACE_SEPARATOR;
-            $transientName = "{$poolName}{$separator}{$key}";
-            $optionName = "_transient_$transientName";
             $notThereKey = uniqid('not-there');
-            $notThereTransientName = "{$poolName}{$separator}{$notThereKey}";
-            $notThereOptionName = "_transient_$notThereTransientName";
-            $subject = $this->createInstance($wpdb, $poolName,$defaultValue );
+            $subject = $this->createInstance($wpdb, $poolName, $defaultValue);
         }
 
         {
+            Functions\expect('get_transient')
+                ->andReturnValues([uniqid('value'), false]);
+
             Functions\expect('get_option')
-                ->andReturnValues([uniqid('value'), $defaultValue]);
+                ->andReturnValues([$defaultValue]);
         }
 
         {


### PR DESCRIPTION
Fixes #4