### PR TITLE
Clear not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Fixed
+- `CachePool#clear()` not working (#11).
 
 ## [0.1.0-alpha3] - 2020-07-08
 ### Added

--- a/src/CachePool.php
+++ b/src/CachePool.php
@@ -447,7 +447,7 @@ class CachePool implements CacheInterface
         $tableName = $this->getTableName(static::TABLE_NAME_OPTIONS);
         $fieldName = static::FIELD_NAME_OPTION_NAME;
         $prefix = $this->getOptionNamePrefix();
-        $query = "SELECT `$fieldName` FROM `$tableName` WHERE `$fieldName` LIKE '%$prefix'";
+        $query = "SELECT `$fieldName` FROM `$tableName` WHERE `$fieldName` LIKE '$prefix%'";
         $results = $this->selectColumn($query, $fieldName);
         $keys = $this->getCacheKeysFromOptionNames($results);
 

--- a/src/CachePool.php
+++ b/src/CachePool.php
@@ -466,9 +466,17 @@ class CachePool implements CacheInterface
     protected function selectColumn(string $query, string $columnName, array $args = []): iterable
     {
         $query = $this->prepareQuery($query, $args);
-        $results = $this->wpdb->get_col($query, $columnName);
+        $results = $this->wpdb->get_results($query, ARRAY_A);
 
-        return $results;
+        $column = [];
+        foreach ($results as $row) {
+            $value = array_key_exists($columnName, $row)
+                ? $row[$columnName]
+                : null;
+            $column[] = $value;
+        }
+
+        return $column;
     }
 
     /**

--- a/tests/functional/CachePoolTest.php
+++ b/tests/functional/CachePoolTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\InvalidArgumentException;
 use wpdb;
+use WpOop\TransientCache\CachePool;
 use WpOop\TransientCache\CachePool as TestSubject;
 use PHPUnit\Framework\TestCase;
 use Brain\Monkey\Functions;
@@ -44,7 +45,7 @@ class CachePoolTest extends TestCase
     {
         require_once(ROOT_DIR . '/vendor/johnpbloch/wordpress-core/wp-includes/wp-db.php');
         $mock = $this->getMockBuilder(wpdb::class)
-            ->setMethods(['get_col', 'query', '_real_escape'])
+            ->setMethods(['get_col', 'query', '_real_escape', 'get_results'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -88,11 +89,11 @@ class CachePoolTest extends TestCase
 
         {
             $options = array_map(function ($value) use ($poolName) {
-                return "_transient_$poolName/$value";
+                return ['option_name' => "_transient_$poolName/$value"];
             }, $keys);
             $wpdb->expects($this->exactly(1))
-                ->method('get_col')
-                ->with("SELECT `option_name` FROM `{$tablePrefix}options` WHERE `option_name` LIKE '%_transient_$poolName/'")
+                ->method('get_results')
+                ->with("SELECT `option_name` FROM `{$tablePrefix}options` WHERE `option_name` LIKE '_transient_$poolName/%'", ARRAY_A)
                 ->will($this->returnValue($options));
 
             Functions\expect('has_filter')

--- a/tests/functional/SilentPoolTest.php
+++ b/tests/functional/SilentPoolTest.php
@@ -47,7 +47,7 @@ class SilentPoolTest extends TestCase
     {
         require_once(ROOT_DIR . '/vendor/johnpbloch/wordpress-core/wp-includes/wp-db.php');
         $mock = $this->getMockBuilder(wpdb::class)
-            ->setMethods(['get_col', 'query', '_real_escape'])
+            ->setMethods(['get_col', 'query', '_real_escape', 'get_results'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -106,9 +106,9 @@ class SilentPoolTest extends TestCase
             "{$pref}{$poolName}{$sep}" . uniqid('key3') => uniqid('val3'),
         ];
         $wpdb->expects($this->any())
-            ->method('get_col')
-            ->with("SELECT `option_name` FROM `{$tablePrefix}options` WHERE `option_name` LIKE '%_transient_$poolName/'")
-            ->will($this->returnValue(array_keys($options)));
+            ->method('get_results')
+            ->with("SELECT `option_name` FROM `{$tablePrefix}options` WHERE `option_name` LIKE '_transient_$poolName/%'")
+            ->will($this->returnValue($options));
 
         $defaultValue = $defaultValue ?? $this->generateRandomString(25);
         $defaultTtl = rand(1, 99999);


### PR DESCRIPTION
## Symptoms
When using `CachePool#clear()`, nothing happens: it silently fails.

## Possible Cause
This is due to 2 things:

1. The [query][1] used in `#getAllKeys()` is incorrect: it puts the variable part of the option name _before_ the prefix. But by definition of the prefix, the variable part has to come after.
2. `#selectColumn()` uses `wpdb#get_col()`, which actually accepts a column _number_ rather than the column _name_. This has been described in #11.

## Suggested Solution
This PR fixes #11 by correcting the query, and adding a userland implementation of column selection.

[1]: https://github.com/wp-oop/transient-cache/blob/develop/src/CachePool.php#L450