### PR TITLE
No longer throw when false-negative result setting same value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Fixed
+- Setting same value as existing caused an exception due to false-negative result (#22).
 
 ## [0.2.0-alpha1] - 2023-08-30
 ### Removed

--- a/src/CachePool.php
+++ b/src/CachePool.php
@@ -350,6 +350,7 @@ class CachePool implements CacheInterface
      * @param int    $ttl   The amount of seconds after which the transient will expire.
      *
      * @throws RangeException If key invalid.
+     * @throws UnexpectedValueException If could not write the value to WP Transients API.
      * @throws RuntimeException If problem setting.
      */
     protected function setTransient(string $key, $value, int $ttl): void
@@ -357,7 +358,12 @@ class CachePool implements CacheInterface
         $this->validateTransientKey($key);
 
         if (!set_transient($key, $value, $ttl)) {
-            throw new RuntimeException(sprintf('set_transient() failed with key "%1$s" with TTL %2$ss', $key, $ttl));
+            $actualValue = $this->getTransient($key);
+            if ($actualValue !== $value) {
+                throw new UnexpectedValueException(
+                    sprintf('set_transient() failed with key "%1$s" with TTL %2$ss', $key, $ttl)
+                );
+            }
         }
     }
 


### PR DESCRIPTION
This addresses #17 by, in the scenario where setting a transient fails, checking if the existing value is the same as new one before throwing.